### PR TITLE
Make Ops classes accessible from sub-Ops classes

### DIFF
--- a/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/AudioOps.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/AudioOps.java
@@ -34,8 +34,11 @@ import org.tensorflow.types.TString;
 public final class AudioOps {
   private final Scope scope;
 
-  AudioOps(Scope scope) {
-    this.scope = scope;
+  private final Ops ops;
+
+  AudioOps(Ops ops) {
+    this.scope = ops.scope();
+    this.ops = ops;
   }
 
   /**
@@ -143,5 +146,12 @@ public final class AudioOps {
   public Mfcc mfcc(Operand<TFloat32> spectrogram, Operand<TInt32> sampleRate,
       Mfcc.Options... options) {
     return Mfcc.create(scope, spectrogram, sampleRate, options);
+  }
+
+  /**
+   * Get the parent {@link Ops} object.
+   */
+  public final Ops ops() {
+    return ops;
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/BitwiseOps.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/BitwiseOps.java
@@ -34,8 +34,11 @@ import org.tensorflow.types.family.TNumber;
 public final class BitwiseOps {
   private final Scope scope;
 
-  BitwiseOps(Scope scope) {
-    this.scope = scope;
+  private final Ops ops;
+
+  BitwiseOps(Ops ops) {
+    this.scope = ops.scope();
+    this.ops = ops;
   }
 
   /**
@@ -267,5 +270,12 @@ public final class BitwiseOps {
    */
   public <T extends TNumber> RightShift<T> rightShift(Operand<T> x, Operand<T> y) {
     return RightShift.create(scope, x, y);
+  }
+
+  /**
+   * Get the parent {@link Ops} object.
+   */
+  public final Ops ops() {
+    return ops;
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/DataExperimentalOps.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/DataExperimentalOps.java
@@ -33,8 +33,11 @@ import org.tensorflow.types.TString;
 public final class DataExperimentalOps {
   private final Scope scope;
 
-  DataExperimentalOps(Scope scope) {
-    this.scope = scope;
+  private final Ops ops;
+
+  DataExperimentalOps(Ops ops) {
+    this.scope = ops.scope();
+    this.ops = ops;
   }
 
   /**
@@ -57,5 +60,12 @@ public final class DataExperimentalOps {
       List<DataType<?>> outputTypes, List<Shape> outputShapes,
       DataServiceDataset.Options... options) {
     return DataServiceDataset.create(scope, datasetId, processingMode, address, protocol, jobName, maxOutstandingRequests, iterationCounter, outputTypes, outputShapes, options);
+  }
+
+  /**
+   * Get the parent {@link Ops} object.
+   */
+  public final Ops ops() {
+    return ops;
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/DataOps.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/DataOps.java
@@ -60,9 +60,12 @@ public final class DataOps {
 
   private final Scope scope;
 
-  DataOps(Scope scope) {
-    this.scope = scope;
-    experimental = new DataExperimentalOps(scope);
+  private final Ops ops;
+
+  DataOps(Ops ops) {
+    this.scope = ops.scope();
+    this.ops = ops;
+    experimental = new DataExperimentalOps(ops);
   }
 
   /**
@@ -409,5 +412,12 @@ public final class DataOps {
   public ZipDataset zipDataset(Iterable<Operand<?>> inputDatasets, List<DataType<?>> outputTypes,
       List<Shape> outputShapes) {
     return ZipDataset.create(scope, inputDatasets, outputTypes, outputShapes);
+  }
+
+  /**
+   * Get the parent {@link Ops} object.
+   */
+  public final Ops ops() {
+    return ops;
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/DtypesOps.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/DtypesOps.java
@@ -33,8 +33,11 @@ import org.tensorflow.types.family.TType;
 public final class DtypesOps {
   private final Scope scope;
 
-  DtypesOps(Scope scope) {
-    this.scope = scope;
+  private final Ops ops;
+
+  DtypesOps(Ops ops) {
+    this.scope = ops.scope();
+    this.ops = ops;
   }
 
   /**
@@ -101,5 +104,12 @@ public final class DtypesOps {
   public <U extends TType, T extends TNumber> Complex<U> complex(Operand<T> real, Operand<T> imag,
       DataType<U> Tout) {
     return Complex.create(scope, real, imag, Tout);
+  }
+
+  /**
+   * Get the parent {@link Ops} object.
+   */
+  public final Ops ops() {
+    return ops;
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/ImageOps.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/ImageOps.java
@@ -66,8 +66,11 @@ import org.tensorflow.types.family.TType;
 public final class ImageOps {
   private final Scope scope;
 
-  ImageOps(Scope scope) {
-    this.scope = scope;
+  private final Ops ops;
+
+  ImageOps(Ops ops) {
+    this.scope = ops.scope();
+    this.ops = ops;
   }
 
   /**
@@ -941,5 +944,12 @@ public final class ImageOps {
       Operand<TInt32> size, Operand<TFloat32> scale, Operand<TFloat32> translation,
       ScaleAndTranslate.Options... options) {
     return ScaleAndTranslate.create(scope, images, size, scale, translation, options);
+  }
+
+  /**
+   * Get the parent {@link Ops} object.
+   */
+  public final Ops ops() {
+    return ops;
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/IoOps.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/IoOps.java
@@ -82,8 +82,11 @@ import org.tensorflow.types.family.TType;
 public final class IoOps {
   private final Scope scope;
 
-  IoOps(Scope scope) {
-    this.scope = scope;
+  private final Ops ops;
+
+  IoOps(Ops ops) {
+    this.scope = ops.scope();
+    this.ops = ops;
   }
 
   /**
@@ -1029,5 +1032,12 @@ public final class IoOps {
    */
   public WriteFile writeFile(Operand<TString> filename, Operand<TString> contents) {
     return WriteFile.create(scope, filename, contents);
+  }
+
+  /**
+   * Get the parent {@link Ops} object.
+   */
+  public final Ops ops() {
+    return ops;
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/LinalgOps.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/LinalgOps.java
@@ -78,8 +78,11 @@ import org.tensorflow.types.family.TType;
 public final class LinalgOps {
   private final Scope scope;
 
-  LinalgOps(Scope scope) {
-    this.scope = scope;
+  private final Ops ops;
+
+  LinalgOps(Ops ops) {
+    this.scope = ops.scope();
+    this.ops = ops;
   }
 
   /**
@@ -1605,5 +1608,12 @@ public final class LinalgOps {
   public <T extends TType> TriangularSolve<T> triangularSolve(Operand<T> matrix, Operand<T> rhs,
       TriangularSolve.Options... options) {
     return TriangularSolve.create(scope, matrix, rhs, options);
+  }
+
+  /**
+   * Get the parent {@link Ops} object.
+   */
+  public final Ops ops() {
+    return ops;
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/MathOps.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/MathOps.java
@@ -138,8 +138,11 @@ import org.tensorflow.types.family.TType;
 public final class MathOps {
   private final Scope scope;
 
-  MathOps(Scope scope) {
-    this.scope = scope;
+  private final Ops ops;
+
+  MathOps(Ops ops) {
+    this.scope = ops.scope();
+    this.ops = ops;
   }
 
   /**
@@ -2390,5 +2393,12 @@ public final class MathOps {
    */
   public <T extends TNumber> Zeta<T> zeta(Operand<T> x, Operand<T> q) {
     return Zeta.create(scope, x, q);
+  }
+
+  /**
+   * Get the parent {@link Ops} object.
+   */
+  public final Ops ops() {
+    return ops;
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/NnOps.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/NnOps.java
@@ -108,9 +108,12 @@ public final class NnOps {
 
   private final Scope scope;
 
-  NnOps(Scope scope) {
-    this.scope = scope;
-    raw = new NnRawOps(scope);
+  private final Ops ops;
+
+  NnOps(Ops ops) {
+    this.scope = ops.scope();
+    this.ops = ops;
+    raw = new NnRawOps(ops);
   }
 
   /**
@@ -2147,5 +2150,12 @@ public final class NnOps {
   public <T extends TNumber> TopK<T> topK(Operand<T> input, Operand<TInt32> k,
       TopK.Options... options) {
     return TopK.create(scope, input, k, options);
+  }
+
+  /**
+   * Get the parent {@link Ops} object.
+   */
+  public final Ops ops() {
+    return ops;
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/NnRawOps.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/NnRawOps.java
@@ -30,8 +30,11 @@ import org.tensorflow.types.family.TNumber;
 public final class NnRawOps {
   private final Scope scope;
 
-  NnRawOps(Scope scope) {
-    this.scope = scope;
+  private final Ops ops;
+
+  NnRawOps(Ops ops) {
+    this.scope = ops.scope();
+    this.ops = ops;
   }
 
   /**
@@ -70,5 +73,12 @@ public final class NnRawOps {
   public <T extends TNumber, U extends TNumber> SparseSoftmaxCrossEntropyWithLogits<T> sparseSoftmaxCrossEntropyWithLogits(
       Operand<T> features, Operand<U> labels) {
     return SparseSoftmaxCrossEntropyWithLogits.create(scope, features, labels);
+  }
+
+  /**
+   * Get the parent {@link Ops} object.
+   */
+  public final Ops ops() {
+    return ops;
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/Ops.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/Ops.java
@@ -347,33 +347,33 @@ public final class Ops {
 
   public final SignalOps signal;
 
-  public final QuantizationOps quantization;
-
   public final TrainOps train;
+
+  public final QuantizationOps quantization;
 
   private final Scope scope;
 
   private Ops(Scope scope) {
     this.scope = scope;
-    nn = new NnOps(scope);
-    summary = new SummaryOps(scope);
-    image = new ImageOps(scope);
-    ragged = new RaggedOps(scope);
-    data = new DataOps(scope);
-    shape = new ShapeOps(scope);
-    io = new IoOps(scope);
-    dtypes = new DtypesOps(scope);
-    xla = new XlaOps(scope);
-    linalg = new LinalgOps(scope);
-    random = new RandomOps(scope);
-    strings = new StringsOps(scope);
-    sparse = new SparseOps(scope);
-    bitwise = new BitwiseOps(scope);
-    math = new MathOps(scope);
-    audio = new AudioOps(scope);
-    signal = new SignalOps(scope);
-    quantization = new QuantizationOps(scope);
-    train = new TrainOps(scope);
+    nn = new NnOps(this);
+    summary = new SummaryOps(this);
+    image = new ImageOps(this);
+    ragged = new RaggedOps(this);
+    data = new DataOps(this);
+    shape = new ShapeOps(this);
+    io = new IoOps(this);
+    dtypes = new DtypesOps(this);
+    xla = new XlaOps(this);
+    linalg = new LinalgOps(this);
+    random = new RandomOps(this);
+    strings = new StringsOps(this);
+    sparse = new SparseOps(this);
+    bitwise = new BitwiseOps(this);
+    math = new MathOps(this);
+    audio = new AudioOps(this);
+    signal = new SignalOps(this);
+    train = new TrainOps(this);
+    quantization = new QuantizationOps(this);
   }
 
   /**

--- a/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/QuantizationOps.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/QuantizationOps.java
@@ -45,8 +45,11 @@ import org.tensorflow.types.family.TType;
 public final class QuantizationOps {
   private final Scope scope;
 
-  QuantizationOps(Scope scope) {
-    this.scope = scope;
+  private final Ops ops;
+
+  QuantizationOps(Ops ops) {
+    this.scope = ops.scope();
+    this.ops = ops;
   }
 
   /**
@@ -627,5 +630,12 @@ public final class QuantizationOps {
       Operand<TFloat32> inputMin, Operand<TFloat32> inputMax, Operand<TFloat32> requestedOutputMin,
       Operand<TFloat32> requestedOutputMax, DataType<U> outType) {
     return Requantize.create(scope, input, inputMin, inputMax, requestedOutputMin, requestedOutputMax, outType);
+  }
+
+  /**
+   * Get the parent {@link Ops} object.
+   */
+  public final Ops ops() {
+    return ops;
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/RaggedOps.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/RaggedOps.java
@@ -30,8 +30,11 @@ import org.tensorflow.types.family.TNumber;
 public final class RaggedOps {
   private final Scope scope;
 
-  RaggedOps(Scope scope) {
-    this.scope = scope;
+  private final Ops ops;
+
+  RaggedOps(Ops ops) {
+    this.scope = ops.scope();
+    this.ops = ops;
   }
 
   /**
@@ -59,5 +62,12 @@ public final class RaggedOps {
       Operand<TInt64> splits, Operand<T> values, Operand<T> size, Operand<U> weights,
       RaggedBincount.Options... options) {
     return RaggedBincount.create(scope, splits, values, size, weights, options);
+  }
+
+  /**
+   * Get the parent {@link Ops} object.
+   */
+  public final Ops ops() {
+    return ops;
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/RandomOps.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/RandomOps.java
@@ -52,8 +52,11 @@ import org.tensorflow.types.family.TType;
 public final class RandomOps {
   private final Scope scope;
 
-  RandomOps(Scope scope) {
-    this.scope = scope;
+  private final Ops ops;
+
+  RandomOps(Ops ops) {
+    this.scope = ops.scope();
+    this.ops = ops;
   }
 
   /**
@@ -582,5 +585,12 @@ public final class RandomOps {
   public UniformCandidateSampler uniformCandidateSampler(Operand<TInt64> trueClasses, Long numTrue,
       Long numSampled, Boolean unique, Long rangeMax, UniformCandidateSampler.Options... options) {
     return UniformCandidateSampler.create(scope, trueClasses, numTrue, numSampled, unique, rangeMax, options);
+  }
+
+  /**
+   * Get the parent {@link Ops} object.
+   */
+  public final Ops ops() {
+    return ops;
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/ShapeOps.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/ShapeOps.java
@@ -34,8 +34,11 @@ import org.tensorflow.types.family.TType;
 public final class ShapeOps {
   private final Scope scope;
 
-  ShapeOps(Scope scope) {
-    this.scope = scope;
+  private final Ops ops;
+
+  ShapeOps(Ops ops) {
+    this.scope = ops.scope();
+    this.ops = ops;
   }
 
   /**
@@ -468,5 +471,12 @@ public final class ShapeOps {
    */
   public <U extends TNumber> Operand<U> takeLast(Shape<U> shape, Operand<U> n, DataType<U> dType) {
     return Shapes.takeLast(scope, shape, n, dType);
+  }
+
+  /**
+   * Get the parent {@link Ops} object.
+   */
+  public final Ops ops() {
+    return ops;
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/SignalOps.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/SignalOps.java
@@ -50,8 +50,11 @@ import org.tensorflow.types.family.TType;
 public final class SignalOps {
   private final Scope scope;
 
-  SignalOps(Scope scope) {
-    this.scope = scope;
+  private final Ops ops;
+
+  SignalOps(Ops ops) {
+    this.scope = ops.scope();
+    this.ops = ops;
   }
 
   /**
@@ -433,5 +436,12 @@ public final class SignalOps {
   public <U extends TType, T extends TNumber> Rfft3d<U> rfft3d(Operand<T> input,
       Operand<TInt32> fftLength, DataType<U> Tcomplex) {
     return Rfft3d.create(scope, input, fftLength, Tcomplex);
+  }
+
+  /**
+   * Get the parent {@link Ops} object.
+   */
+  public final Ops ops() {
+    return ops;
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/SparseOps.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/SparseOps.java
@@ -80,8 +80,11 @@ import org.tensorflow.types.family.TType;
 public final class SparseOps {
   private final Scope scope;
 
-  SparseOps(Scope scope) {
-    this.scope = scope;
+  private final Ops ops;
+
+  SparseOps(Ops ops) {
+    this.scope = ops.scope();
+    this.ops = ops;
   }
 
   /**
@@ -1496,5 +1499,12 @@ public final class SparseOps {
       Operand<TInt64> sparseHandles, DataType<T> dtype,
       TakeManySparseFromTensorsMap.Options... options) {
     return TakeManySparseFromTensorsMap.create(scope, sparseHandles, dtype, options);
+  }
+
+  /**
+   * Get the parent {@link Ops} object.
+   */
+  public final Ops ops() {
+    return ops;
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/StringsOps.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/StringsOps.java
@@ -52,8 +52,11 @@ import org.tensorflow.types.family.TNumber;
 public final class StringsOps {
   private final Scope scope;
 
-  StringsOps(Scope scope) {
-    this.scope = scope;
+  private final Ops ops;
+
+  StringsOps(Ops ops) {
+    this.scope = ops.scope();
+    this.ops = ops;
   }
 
   /**
@@ -616,5 +619,12 @@ public final class StringsOps {
    */
   public Upper upper(Operand<TString> input, Upper.Options... options) {
     return Upper.create(scope, input, options);
+  }
+
+  /**
+   * Get the parent {@link Ops} object.
+   */
+  public final Ops ops() {
+    return ops;
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/SummaryOps.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/SummaryOps.java
@@ -37,8 +37,11 @@ import org.tensorflow.types.family.TType;
 public final class SummaryOps {
   private final Scope scope;
 
-  SummaryOps(Scope scope) {
-    this.scope = scope;
+  private final Ops ops;
+
+  SummaryOps(Ops ops) {
+    this.scope = ops.scope();
+    this.ops = ops;
   }
 
   /**
@@ -194,5 +197,12 @@ public final class SummaryOps {
   public <T extends TType> TensorSummary tensorSummary(Operand<TString> tag, Operand<T> tensor,
       Operand<TString> serializedSummaryMetadata) {
     return TensorSummary.create(scope, tag, tensor, serializedSummaryMetadata);
+  }
+
+  /**
+   * Get the parent {@link Ops} object.
+   */
+  public final Ops ops() {
+    return ops;
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/TrainOps.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/TrainOps.java
@@ -98,8 +98,11 @@ import org.tensorflow.types.family.TType;
 public final class TrainOps {
   private final Scope scope;
 
-  TrainOps(Scope scope) {
-    this.scope = scope;
+  private final Ops ops;
+
+  TrainOps(Ops ops) {
+    this.scope = ops.scope();
+    this.ops = ops;
   }
 
   /**
@@ -1657,5 +1660,12 @@ public final class TrainOps {
    */
   public <T extends TType> TileGrad<T> tileGrad(Operand<T> input, Operand<TInt32> multiples) {
     return TileGrad.create(scope, input, multiples);
+  }
+
+  /**
+   * Get the parent {@link Ops} object.
+   */
+  public final Ops ops() {
+    return ops;
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/XlaOps.java
+++ b/tensorflow-core/tensorflow-core-api/src/gen/annotations/org/tensorflow/op/XlaOps.java
@@ -49,8 +49,11 @@ import org.tensorflow.types.family.TType;
 public final class XlaOps {
   private final Scope scope;
 
-  XlaOps(Scope scope) {
-    this.scope = scope;
+  private final Ops ops;
+
+  XlaOps(Ops ops) {
+    this.scope = ops.scope();
+    this.ops = ops;
   }
 
   /**
@@ -378,5 +381,12 @@ public final class XlaOps {
   public <T extends TType> Svd<T> svd(Operand<T> a, Long maxIter, Float epsilon,
       String precisionConfig) {
     return Svd.create(scope, a, maxIter, epsilon, precisionConfig);
+  }
+
+  /**
+   * Get the parent {@link Ops} object.
+   */
+  public final Ops ops() {
+    return ops;
   }
 }


### PR DESCRIPTION
I adjust codegen to make ops group classes take Ops instead of Scope, get their Scope from it, save it in a field (`ops`), and provide an accessor for that field (`ops()`).

Fixes #147.